### PR TITLE
feat: get public keys based on a supplied bip32 address index

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,33 @@ You should see a similar output, just with different hex values:
 name: tari
 package version: 0.0.1
 
-challange as secretkey: 260dda4598fcfa2bc8b2744f3fc3d65ea29258aeb7a0d93babc483ca436e8503
-signature: 46b66cefc6c3f9f5acae802c223d1e9684fe3dc9581967cb2e34797ef632fc0f
+challenge:  907427e1444d8fb652f3d8a580b5ad9b630938b3f05041781efd643f5d5c6a0c
+signature:  584d7c2c8ee2f08568635553cccd13d10f3a1345ef07142f58dd1216c0eb8203
 public key: dad90c3bd61ac63b51181b7f56c3b17afbe33ad2143eba3b5ba3755a5284710c
-sign: true
+sign:       true
 
 commitment: 3a587a548f9076818dd4d2a328f2b6d9905c08f7aa786135b90826eac4a1134e
+
+path:       m/44'/535348'/0'/0/0
+public_key: dad90c3bd61ac63b51181b7f56c3b17afbe33ad2143eba3b5ba3755a5284710c
+path:       m/44'/535348'/0'/0/1
+public_key: 1cec04609602115212fd60fd94a91c6f870d0d7dd9196f1e5d7dcc178a45ac31
+path:       m/44'/535348'/0'/0/2
+public_key: f8a7fc373821fe111056c5ef9b56b8b09e16b4ab870051dd7a1fd9f93e510b77
+path:       m/44'/535348'/0'/0/3
+public_key: 061c33e40b423ed96eae0d4cea89f3716ddd40c48aa8050ccf89f701667b4579
+path:       m/44'/535348'/0'/0/4
+public_key: d0e2fd4e8a2ac58113c91d9ec17c2b780718eb20dfaa8bd3e88006aee59f4a5f
+path:       m/44'/535348'/0'/0/5
+public_key: be38fa70d498d6092c84272d9aafcd291a80f61b6b0a075ed1f8f98fa9288c3b
+path:       m/44'/535348'/0'/0/6
+public_key: c8cf60ea96f4585fb399c41dab3b44c528a74bca0d20b95e0752e08c7d61f012
+path:       m/44'/535348'/0'/0/7
+public_key: 26d4be20928e2380be6ceb331012343159eb853bfe478cf82631779ebedd360d
+path:       m/44'/535348'/0'/0/8
+public_key: 68b53190bbda74d6f91d38f56e4c1fa3dd4dda600274153007554f62c787ab6b
+path:       m/44'/535348'/0'/0/9
+public_key: 70a143730591525176312c9555dec97b7ab543ae8a95f7d8a69eeaad43f54540
 
 Ledger device disconnected (APDUAnswer { data: [144, 0], retcode: 36864 })
 ```

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -52,12 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,9 +466,6 @@ dependencies = [
  "ledger-zondax-generic",
  "once_cell",
  "rand",
- "serial_test",
- "tari-curve25519-dalek",
- "tari_bulletproofs_plus",
  "tari_crypto",
  "tari_utilities",
 ]
@@ -484,16 +475,6 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -538,29 +519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,30 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -672,15 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,22 +615,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
-
-[[package]]
 name = "ryu"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -745,31 +658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19dbfb999a147cedbfe82f042eb9555f5b0fa4ef95ee4570b74349103d9c9f4"
-dependencies = [
- "lazy_static 1.4.0",
- "log",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9e2050b2be1d681f8f1c1a528bcfe4e00afa2d8995f713974f5333288659f2"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,12 +675,6 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snafu"
@@ -1016,63 +898,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-targets"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "zeroize"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 
 [dependencies]
 
-
 once_cell = "1"
-serial_test = "0.7.0"
 ledger-zondax-generic = { git = "https://github.com/Zondax/ledger-rs" }
 ledger-transport = { git = "https://github.com/Zondax/ledger-rs" }
 ledger-transport-hid = { git = "https://github.com/Zondax/ledger-rs" }
@@ -17,7 +15,5 @@ futures = "0.3"
 tari_crypto = { git = "https://github.com/hansieodendaal/tari-crypto.git",  rev = "d6dd58b4657b2b8003ddac328eccd5b9f2597e79" }
 rand = "0.8.5"
 borsh = { version = "0.10", default-features = false }
-curve25519-dalek = { package = "tari-curve25519-dalek", git = "https://github.com/tari-project/curve25519-dalek.git", version = "4.0.3" }
 digest = "0.10.6"
 tari_utilities = { git = "https://github.com/tari-project/tari_utilities.git", version = "0.5", default-features = false }
-bulletproofs_plus = { package = "tari_bulletproofs_plus", git = "https://github.com/tari-project/bulletproofs-plus", version = "0.3" }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -17,8 +17,8 @@ digest = { version = "0.10", default-features = false }
 rand_core = {version = "0.6", default-features = false}
 embedded-alloc = "0.5.0"
 borsh = { version = "0.10", default-features = false }
-
 critical-section = { version = "1.1.1" }
+
 [profile.release]
 opt-level = 's'
 lto = "fat" # same as `true`


### PR DESCRIPTION
Added requesting public keys from the ledger device by passing the address index in the BIP32 path.

`m / purpose' / coin_type' / account' / change / address_index`